### PR TITLE
Convert buttons with get actions to links

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -55,6 +55,6 @@ iframe {
 }
 
 .back-button {
-  margin-top: 1em;
-  margin-bottom: 1em;
+  margin-top: 2em;
+  margin-bottom: 2em;
 }

--- a/app/views/activities/index.html.slim
+++ b/app/views/activities/index.html.slim
@@ -7,5 +7,6 @@ ul#activity-list.list-unstyled
         = hidden_field_tag :user_id, @user.id if @user
         = hidden_field_tag :activity_id, activity.id
         = button_tag activity.name, class: "btn btn-block btn-primary"
+
 ul#navigation-buttons.list-unstyled
-  li = button_to t('action.go_back'), welcome_path, method: "get", class: "btn btn-block btn-danger"
+  li = link_to t('action.go_back'), welcome_path, class: "btn btn-block btn-danger button-back"

--- a/app/views/activity_sessions/index.html.slim
+++ b/app/views/activity_sessions/index.html.slim
@@ -18,6 +18,5 @@ table.table.growhaus-sign-in-table
                 = hidden_field_tag :checkout, "true"
                 = button_tag "#{t('action.check_out')}", class: "btn btn-default"
 
-ul#navigation-buttons.list-unstyled
-  li = button_to t('action.check_in'), user_activities_path, method: "get", class: "btn btn-block btn-primary"
-  li = button_to t('action.go_back'), welcome_path, method: "get", class: "btn btn-block btn-danger"
+= link_to t('action.check_in'), user_activities_path, class: "btn btn-block btn-primary"
+= link_to t('action.go_back'), welcome_path, class: "btn btn-block btn-danger button-back"

--- a/app/views/pages/login.html.slim
+++ b/app/views/pages/login.html.slim
@@ -1,1 +1,1 @@
-= button_to t('login.log_in'), "/auth/google_oauth2", method: "get", class: "btn btn-block button-center"
+= link_to t('login.log_in'), "/auth/google_oauth2", class: "btn btn-primary btn-block button-center"

--- a/app/views/users/index.html.slim
+++ b/app/views/users/index.html.slim
@@ -9,5 +9,4 @@ table.table.dataTable.growhaus-sign-in-table
       tr
         td = link_to user.name, user_activity_sessions_path(user.id)
 
-ul#navigation-buttons.list-unstyled
-  li = button_to t('action.go_back'), welcome_path, method: "get", class: "btn btn-block btn-danger"
+= link_to t('action.go_back'), welcome_path, class: "btn btn-block btn-danger button-back"

--- a/app/views/users/new.html.slim
+++ b/app/views/users/new.html.slim
@@ -2,4 +2,4 @@ h1 = t('user.new_title')
 
 = render 'form'
 
-= button_to t('action.back'), users_path, method: "get", class: "btn btn-block btn-danger back-button"
+= link_to t('action.back'), users_path, class: "btn btn-block btn-danger back-button"

--- a/spec/features/pages_spec.rb
+++ b/spec/features/pages_spec.rb
@@ -8,9 +8,9 @@ RSpec.describe "Pages", type: :feature do
 
     it "can sign in user with Google account" do
       visit '/'
-      expect(page).to have_selector("input[type=submit][value='Log In']")
+      expect(page).to have_content("Log In")
       mock_auth_hash
-      click_button 'Log In'
+      click_link 'Log In'
       expect(page).to have_content('mockuser')
       #page.should have_css('img', :src => 'mock_user_thumbnail_url') # user image
       #page.should have_content("Sign out")
@@ -19,8 +19,8 @@ RSpec.describe "Pages", type: :feature do
     it "can handle authentication error" do
       OmniAuth.config.mock_auth[:google] = :invalid_credentials
       visit '/'
-      expect(page).to have_selector("input[type=submit][value='Log In']")
-      click_button 'Log In'
+      expect(page).to have_content("Log In")
+      click_link "Log In"
       #expect(page).to have_content('Log In')
     end
 


### PR DESCRIPTION
Because bootstrap styling can make them behave like buttons
without the form overhead